### PR TITLE
Use SUPABASE_SERVICE_KEY environment variable

### DIFF
--- a/app/api/debug-env/route.ts
+++ b/app/api/debug-env/route.ts
@@ -2,12 +2,12 @@
 import { NextResponse } from 'next/server';
 
 export async function GET() {
-  const hasService = !!process.env.SUPABASE_SERVICE_ROLE;
+  const hasServiceKey = !!process.env.SUPABASE_SERVICE_KEY;
   const hasUrl = !!process.env.NEXT_PUBLIC_SUPABASE_URL;
   const hasAnon = !!process.env.NEXT_PUBLIC_SUPABASE_KEY;
 
   return NextResponse.json({
-    hasService,
+    hasServiceKey,
     hasUrl,
     hasAnon,
   });

--- a/app/api/properties/route.ts
+++ b/app/api/properties/route.ts
@@ -10,17 +10,17 @@ export const revalidate = 0
 export async function POST(req: Request) {
   // Create the client at REQUEST TIME (not module top), so it doesn't run during build
   const url = process.env.NEXT_PUBLIC_SUPABASE_URL
-  const serviceRole = process.env.SUPABASE_SERVICE_ROLE
+  const serviceKey = process.env.SUPABASE_SERVICE_KEY
 
-  if (!url || !serviceRole) {
+  if (!url || !serviceKey) {
     // Be explicit so we know which variable is missing if this ever happens in runtime
     return NextResponse.json(
-      { error: `Missing env: ${!url ? 'NEXT_PUBLIC_SUPABASE_URL' : ''} ${!serviceRole ? 'SUPABASE_SERVICE_ROLE' : ''}`.trim() },
+      { error: `Missing env: ${!url ? 'NEXT_PUBLIC_SUPABASE_URL' : ''} ${!serviceKey ? 'SUPABASE_SERVICE_KEY' : ''}`.trim() },
       { status: 500 }
     )
   }
 
-  const supabase = createClient(url, serviceRole, {
+  const supabase = createClient(url, serviceKey, {
     auth: { persistSession: false, autoRefreshToken: false }
   })
 


### PR DESCRIPTION
## Summary
- Replace Supabase service role env var with SUPABASE_SERVICE_KEY in properties API
- Update debug-env route to surface SUPABASE_SERVICE_KEY

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Failed to fetch font `Inter` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68b72cd35da88326834ab3c3ecb50f2b