### PR TITLE
Use SUPABASE_SERVICE_KEY environment variable

### DIFF
--- a/app/api/debug-env/route.ts
+++ b/app/api/debug-env/route.ts
@@ -2,12 +2,12 @@
 import { NextResponse } from 'next/server';
 
 export async function GET() {
-  const hasService = !!process.env.SUPABASE_SERVICE_ROLE;
+  const hasServiceKey = !!process.env.SUPABASE_SERVICE_KEY;
   const hasUrl = !!process.env.NEXT_PUBLIC_SUPABASE_URL;
   const hasAnon = !!process.env.NEXT_PUBLIC_SUPABASE_KEY;
 
   return NextResponse.json({
-    hasService,
+    hasServiceKey,
     hasUrl,
     hasAnon,
   });


### PR DESCRIPTION
## Summary
- Replace Supabase service role env var with SUPABASE_SERVICE_KEY in properties API
- Update debug-env route to surface SUPABASE_SERVICE_KEY
- Handle `address` and `zip` fields in properties API to avoid missing address errors

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Failed to fetch font `Inter` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68b72cd35da88326834ab3c3ecb50f2b