### PR TITLE
Use SUPABASE_SERVICE_KEY environment variable

### DIFF
--- a/app/api/debug-env/route.ts
+++ b/app/api/debug-env/route.ts
@@ -2,12 +2,12 @@
 import { NextResponse } from 'next/server';
 
 export async function GET() {
-  const hasService = !!process.env.SUPABASE_SERVICE_ROLE;
+  const hasServiceKey = !!process.env.SUPABASE_SERVICE_KEY;
   const hasUrl = !!process.env.NEXT_PUBLIC_SUPABASE_URL;
   const hasAnon = !!process.env.NEXT_PUBLIC_SUPABASE_KEY;
 
   return NextResponse.json({
-    hasService,
+    hasServiceKey,
     hasUrl,
     hasAnon,
   });

--- a/app/api/properties/recent/route.ts
+++ b/app/api/properties/recent/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from 'next/server'
+import { getAdminClient } from '@/lib/supabase'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+export const revalidate = 0
+
+export async function GET() {
+  const supabase = getAdminClient()
+  if (!supabase) {
+    return NextResponse.json({ error: 'Server missing Supabase env' }, { status: 500 })
+  }
+
+  const { data, error } = await supabase
+    .from('properties')
+    .select('id, full_address, city, state, postal_code, owner_name, owner_email, created_at')
+    .order('created_at', { ascending: false })
+    .limit(5)
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+  return NextResponse.json({ properties: data ?? [] }, { headers: { 'Cache-Control': 'no-store' } })
+}

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1,6 +1,12 @@
-import { createClient } from '@supabase/supabase-js'
+import { createClient, SupabaseClient } from '@supabase/supabase-js'
 
-export const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.SUPABASE_SERVICE_KEY! // server-only usage
-)
+export function getAdminClient(): SupabaseClient | null {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const serviceKey = process.env.SUPABASE_SERVICE_KEY
+  if (!url || !serviceKey) return null
+  return createClient(url, serviceKey, {
+    auth: { persistSession: false, autoRefreshToken: false }
+  })
+}
+
+export const supabase = getAdminClient()!


### PR DESCRIPTION
## Summary
- Replace Supabase service role env var with SUPABASE_SERVICE_KEY in properties API
- Update debug-env route to surface SUPABASE_SERVICE_KEY
- Handle `address` and `zip` fields in properties API to avoid missing address errors
- Add `getAdminClient` helper and `/api/properties/recent` endpoint returning latest properties

## Testing
- `npm test` *(fails: Missing script "test")*
- `npm run build` *(fails: Failed to fetch font `Inter` from Google Fonts)*

------
https://chatgpt.com/codex/tasks/task_e_68b72cd35da88326834ab3c3ecb50f2b