### PR TITLE
Add PropertyList component and property detail page

### DIFF
--- a/app/api/debug-env/route.ts
+++ b/app/api/debug-env/route.ts
@@ -2,12 +2,12 @@
 import { NextResponse } from 'next/server';
 
 export async function GET() {
-  const hasService = !!process.env.SUPABASE_SERVICE_ROLE;
+  const hasServiceKey = !!process.env.SUPABASE_SERVICE_KEY;
   const hasUrl = !!process.env.NEXT_PUBLIC_SUPABASE_URL;
   const hasAnon = !!process.env.NEXT_PUBLIC_SUPABASE_KEY;
 
   return NextResponse.json({
-    hasService,
+    hasServiceKey,
     hasUrl,
     hasAnon,
   });

--- a/app/api/properties/recent/route.ts
+++ b/app/api/properties/recent/route.ts
@@ -1,0 +1,22 @@
+import { NextResponse } from 'next/server'
+import { getAdminClient } from '@/lib/supabase'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+export const revalidate = 0
+
+export async function GET() {
+  const supabase = getAdminClient()
+  if (!supabase) {
+    return NextResponse.json({ error: 'Server missing Supabase env' }, { status: 500 })
+  }
+
+  const { data, error } = await supabase
+    .from('properties')
+    .select('id, full_address, city, state, postal_code, owner_name, owner_email, created_at')
+    .order('created_at', { ascending: false })
+    .limit(5)
+
+  if (error) return NextResponse.json({ error: error.message }, { status: 500 })
+  return NextResponse.json({ properties: data ?? [] }, { headers: { 'Cache-Control': 'no-store' } })
+}

--- a/app/dashboard/page.tsx
+++ b/app/dashboard/page.tsx
@@ -2,6 +2,7 @@ import PortfolioOverview from '@/components/portfoliooverview'
 import StatCard from '@/components/statcard'
 import PropertyCard from '@/components/propertycard'
 import RecentSalesTable from '@/components/recentsalestable'
+import PropertyList from '@/components/property-list'
 import { sbServer } from '@/lib/server_supabase'
 
 export const revalidate = 30
@@ -59,6 +60,8 @@ export default async function DashboardPage() {
       </section>
 
       <RecentSalesTable data={(sales ?? []) as any} />
+
+      <PropertyList />
     </div>
   )
 }

--- a/app/property/[id]/page.tsx
+++ b/app/property/[id]/page.tsx
@@ -1,0 +1,51 @@
+import { getAdminClient } from '@/lib/supabase'
+
+export const runtime = 'nodejs'
+export const dynamic = 'force-dynamic'
+export const revalidate = 0
+
+export default async function PropertyDetail({ params }: { params: { id: string } }) {
+  const supabase = getAdminClient()
+  if (!supabase) return <div className="p-6 text-red-600">Server missing Supabase env.</div>
+
+  const { data, error } = await supabase
+    .from('properties')
+    .select('*')
+    .eq('id', params.id)
+    .single()
+
+  if (error) return <div className="p-6 text-red-600">Error: {error.message}</div>
+  if (!data) return <div className="p-6">Not found.</div>
+
+  return (
+    <div className="max-w-3xl mx-auto p-6 space-y-4">
+      <h1 className="text-2xl font-semibold">Property</h1>
+      <div className="card p-6">
+        <div className="grid md:grid-cols-2 gap-4 text-sm">
+          <div>
+            <div className="text-gray-500">Address</div>
+            <div>{data.full_address}</div>
+          </div>
+          <div>
+            <div className="text-gray-500">Owner</div>
+            <div>{data.owner_name}</div>
+          </div>
+          <div>
+            <div className="text-gray-500">Email</div>
+            <div>{data.owner_email}</div>
+          </div>
+          <div>
+            <div className="text-gray-500">Created</div>
+            <div>{new Date(data.created_at).toLocaleString()}</div>
+          </div>
+        </div>
+      </div>
+
+      <div className="card p-6">
+        <h3 className="text-lg font-semibold mb-2">Net Sheet</h3>
+        {/* Later we'll bind this to the property values. For now, link to the calculator. */}
+        <a className="btn btn-primary" href="/netsheet">Open Net Sheet</a>
+      </div>
+    </div>
+  )
+}

--- a/components/property-list.tsx
+++ b/components/property-list.tsx
@@ -1,0 +1,82 @@
+'use client'
+
+import { useEffect, useState } from 'react'
+
+type Property = {
+  id: string
+  full_address: string | null
+  city: string | null
+  state: string | null
+  postal_code: string | null
+  owner_name: string | null
+  owner_email: string | null
+  created_at: string
+}
+
+export default function PropertyList() {
+  const [rows, setRows] = useState<Property[]>([])
+  const [loading, setLoading] = useState(true)
+  const [err, setErr] = useState<string | null>(null)
+
+  useEffect(() => {
+    ;(async () => {
+      try {
+        const res = await fetch('/api/properties/recent', { cache: 'no-store' })
+        const json = await res.json()
+        if (!res.ok) throw new Error(json?.error || 'Failed to load properties')
+        setRows(json.properties)
+      } catch (e: any) {
+        setErr(e.message)
+      } finally {
+        setLoading(false)
+      }
+    })()
+  }, [])
+
+  if (loading) return <div className="card p-6">Loading properties…</div>
+  if (err) return <div className="card p-6 text-red-600">Error: {err}</div>
+  if (rows.length === 0) {
+    return (
+      <div className="card p-6">
+        No properties yet. Add one on the{' '}
+        <a className="underline" href="/add">Add Property</a> page.
+      </div>
+    )
+  }
+
+  return (
+    <div className="card p-6">
+      <div className="flex items-center justify-between">
+        <h3 className="text-lg font-semibold">Recent Properties</h3>
+        <a href="/add" className="btn btn-primary">Add Property</a>
+      </div>
+      <div className="mt-4 overflow-x-auto">
+        <table className="min-w-full text-sm">
+          <thead className="text-left text-gray-500">
+            <tr>
+              <th className="py-2 pr-4">Address</th>
+              <th className="py-2 pr-4">Owner</th>
+              <th className="py-2 pr-4">Email</th>
+              <th className="py-2 pr-4">Created</th>
+              <th className="py-2 pr-4"></th>
+            </tr>
+          </thead>
+          <tbody>
+            {rows.map((p) => (
+              <tr key={p.id} className="border-t">
+                <td className="py-2 pr-4">{p.full_address || '—'}</td>
+                <td className="py-2 pr-4">{p.owner_name || '—'}</td>
+                <td className="py-2 pr-4">{p.owner_email || '—'}</td>
+                <td className="py-2 pr-4">{new Date(p.created_at).toLocaleDateString()}</td>
+                <td className="py-2 pr-4">
+                  <a className="text-brand-navy underline" href={`/property/${p.id}`}>Open</a>
+                </td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </div>
+    </div>
+  )
+}
+

--- a/lib/supabase.ts
+++ b/lib/supabase.ts
@@ -1,6 +1,12 @@
-import { createClient } from '@supabase/supabase-js'
+import { createClient, SupabaseClient } from '@supabase/supabase-js'
 
-export const supabase = createClient(
-  process.env.NEXT_PUBLIC_SUPABASE_URL!,
-  process.env.SUPABASE_SERVICE_KEY! // server-only usage
-)
+export function getAdminClient(): SupabaseClient | null {
+  const url = process.env.NEXT_PUBLIC_SUPABASE_URL
+  const serviceKey = process.env.SUPABASE_SERVICE_KEY
+  if (!url || !serviceKey) return null
+  return createClient(url, serviceKey, {
+    auth: { persistSession: false, autoRefreshToken: false }
+  })
+}
+
+export const supabase = getAdminClient()!


### PR DESCRIPTION
## Summary
- add `PropertyList` component that fetches and displays recent properties
- expose `/api/properties/recent` endpoint for fetching latest properties
- render `PropertyList` on dashboard page to quickly access recent entries
- create property detail page at `/property/[id]` to view individual property info and link to net sheet

## Testing
- `npm test` (fails: Missing script "test")
- `npm run build` (fails: Failed to fetch font `Inter` from Google Fonts)


------
https://chatgpt.com/codex/tasks/task_e_68b72cd35da88326834ab3c3ecb50f2b